### PR TITLE
Feat: Dynamic memory allocator. 

### DIFF
--- a/src/bloqade/pyqrack/__init__.py
+++ b/src/bloqade/pyqrack/__init__.py
@@ -6,7 +6,11 @@ from .reg import (
     Measurement as Measurement,
     PyQrackQubit as PyQrackQubit,
 )
-from .base import Memory as Memory, PyQrackInterpreter as PyQrackInterpreter
+from .base import (
+    StackMemory as StackMemory,
+    DynamicMemory as DynamicMemory,
+    PyQrackInterpreter as PyQrackInterpreter,
+)
 from .noise import native as native
 
 # NOTE: The following import is for registering the method tables

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -53,7 +53,7 @@ class DynamicMemory(MemoryABC):
     sim_reg: "QrackSimulator"
 
     def __post_init__(self):
-        if self.sim_reg.is_tensor_network():
+        if self.sim_reg.is_tensor_network:
             raise ValueError("DynamicMemory does not support tensor networks")
 
         self.reset()

--- a/src/bloqade/pyqrack/qasm2/core.py
+++ b/src/bloqade/pyqrack/qasm2/core.py
@@ -54,10 +54,16 @@ class PyQrackMethods(interp.MethodTable):
         qarg: PyQrackQubit = frame.get(stmt.qarg)
         carg: CBitRef = frame.get(stmt.carg)
         if qarg.is_active():
-            carg.set_value(Measurement(qarg.ref.sim_reg.m(qarg.addr)))
+            carg.set_value(Measurement(qarg.sim_reg.m(qarg.addr)))
         else:
             carg.set_value(interp.loss_m_result)
 
+        return ()
+
+    @interp.impl(core.Reset)
+    def reset(self, interp: PyQrackInterpreter, frame: interp.Frame, stmt: core.Reset):
+        qarg: PyQrackQubit = frame.get(stmt.qarg)
+        qarg.sim_reg.force_m(qarg.addr, 0)
         return ()
 
     @interp.impl(core.CRegEq)

--- a/test/runtime/noise/native/test_loss.py
+++ b/test/runtime/noise/native/test_loss.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 from bloqade import qasm2
 from bloqade.noise import native
-from bloqade.pyqrack import Memory, PyQrackInterpreter, reg
+from bloqade.pyqrack import StackMemory, PyQrackInterpreter, reg
 
 simulation = qasm2.extended.add(native)
 
@@ -21,7 +21,7 @@ def test_atom_loss():
     rng_state = Mock()
     rng_state.uniform.return_value = 0.7
     input = reg.CRegister(1)
-    memory = Memory(total=2, allocated=0, sim_reg=Mock())
+    memory = StackMemory(total=2, allocated=0, sim_reg=Mock())
 
     result: reg.PyQrackReg[Mock] = (
         PyQrackInterpreter(simulation, memory=memory, rng_state=rng_state)

--- a/test/runtime/noise/native/test_pauli.py
+++ b/test/runtime/noise/native/test_pauli.py
@@ -3,13 +3,13 @@ from unittest.mock import Mock, call
 from kirin import ir
 from bloqade import qasm2
 from bloqade.noise import native
-from bloqade.pyqrack import Memory, PyQrackInterpreter
+from bloqade.pyqrack import StackMemory, PyQrackInterpreter
 
 simulation = qasm2.extended.add(native)
 
 
 def run_mock(size, program: ir.Method, rng_state: Mock) -> Mock:
-    memory = Memory(total=2, allocated=0, sim_reg=Mock())
+    memory = StackMemory(total=2, allocated=0, sim_reg=Mock())
 
     PyQrackInterpreter(program.dialects, memory=memory, rng_state=rng_state).run(
         program, ()

--- a/test/runtime/test_dyn_memory.py
+++ b/test/runtime/test_dyn_memory.py
@@ -21,7 +21,7 @@ def test():
         return c
 
     target = PyQrack(
-        pyqrack_options={"isBinaryDecisionTree": True, "isTensorNetwork": False},
+        pyqrack_options={"isTensorNetwork": False, "isStabilizerHybrid": True},
         dynamic_qubits=True,
     )
 

--- a/test/runtime/test_dyn_memory.py
+++ b/test/runtime/test_dyn_memory.py
@@ -1,0 +1,32 @@
+from collections import Counter
+
+from bloqade import qasm2
+from bloqade.pyqrack import PyQrack
+
+
+def test():
+
+    @qasm2.extended
+    def ghz(n: int):
+        q = qasm2.qreg(n)
+        c = qasm2.creg(n)
+
+        qasm2.h(q[0])
+        for i in range(1, n):
+            qasm2.cx(q[0], q[i])
+
+        for i in range(n):
+            qasm2.measure(q[i], c[i])
+
+        return c
+
+    target = PyQrack(
+        pyqrack_options={"isBinaryDecisionTree": True, "isTensorNetwork": False},
+        dynamic_qubits=True,
+    )
+
+    N = 50
+
+    result = target.multi_run(ghz, 100, N)
+    result = Counter("".join(str(int(bit)) for bit in bits) for bits in result)
+    assert result.keys() == {"0" * N, "1" * N}

--- a/test/runtime/test_qrack.py
+++ b/test/runtime/test_qrack.py
@@ -7,7 +7,7 @@ from bloqade import qasm2, pyqrack
 
 
 def run_mock(size: int, program: ir.Method) -> Mock:
-    memory = pyqrack.Memory(size, 0, Mock())
+    memory = pyqrack.StackMemory(size, 0, Mock())
     interp = pyqrack.PyQrackInterpreter(qasm2.main, memory=memory)
     interp.run(program, ())
 


### PR DESCRIPTION
This PR refactors the `Memory` interface to make it more general and extends the interface to use pyqrack's dynamic memory allocation of qubits. For now there are not deallocate statements inside the qasm2, so no deallocate method is required for the interface. 


@jon-wurtz here you go!