### PR TITLE
Fix bug in extended dialect runtime. 

### DIFF
--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -12,7 +12,10 @@ if typing.TYPE_CHECKING:
     from pyqrack import QrackSimulator
 
 
+@dataclass
 class MemoryABC(abc.ABC):
+    sim_reg: "QrackSimulator"
+
     @abc.abstractmethod
     def allocate(self, n_qubits: int) -> tuple[int, ...]:
         """Allocate `n_qubits` qubits and return their ids."""
@@ -28,7 +31,6 @@ class MemoryABC(abc.ABC):
 class StackMemory(MemoryABC):
     total: int
     allocated: int
-    sim_reg: "QrackSimulator"
 
     def allocate(self, n_qubits: int):
         curr_allocated = self.allocated
@@ -50,7 +52,6 @@ class StackMemory(MemoryABC):
 
 @dataclass
 class DynamicMemory(MemoryABC):
-    sim_reg: "QrackSimulator"
 
     def __post_init__(self):
         if self.sim_reg.is_tensor_network:

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:
 
 @dataclass
 class MemoryABC(abc.ABC):
-    sim_reg: "QrackSimulator"
+    sim_reg: "QrackSimulator" = field(kw_only=True)
 
     @abc.abstractmethod
     def allocate(self, n_qubits: int) -> tuple[int, ...]:

--- a/src/bloqade/pyqrack/qasm2/parallel.py
+++ b/src/bloqade/pyqrack/qasm2/parallel.py
@@ -17,7 +17,7 @@ class PyQrackMethods(interp.MethodTable):
         ctrls: ilist.IList[PyQrackQubit, Any] = frame.get(stmt.ctrls)
         for qarg, ctrl in zip(qargs, ctrls):
             if qarg.is_active() and ctrl.is_active():
-                interp.memory.sim_reg.mcz(qarg, ctrl)
+                interp.memory.sim_reg.mcz([ctrl.addr], qarg.addr)
         return ()
 
     @interp.impl(parallel.UGate)
@@ -32,7 +32,7 @@ class PyQrackMethods(interp.MethodTable):
         )
         for qarg in qargs:
             if qarg.is_active():
-                interp.memory.sim_reg.u(qarg, theta, phi, lam)
+                interp.memory.sim_reg.u(qarg.addr, theta, phi, lam)
         return ()
 
     @interp.impl(parallel.RZ)
@@ -41,5 +41,5 @@ class PyQrackMethods(interp.MethodTable):
         phi = frame.get(stmt.theta)
         for qarg in qargs:
             if qarg.is_active():
-                interp.memory.sim_reg.r(3, phi, qarg)
+                interp.memory.sim_reg.r(3, phi, qarg.addr)
         return ()

--- a/src/bloqade/pyqrack/target.py
+++ b/src/bloqade/pyqrack/target.py
@@ -66,7 +66,7 @@ class PyQrack:
             num_qubits = max(address_analysis.qubit_count, self.min_qubits)
             self.pyqrack_options.pop("qubitCount", None)
             memory = StackMemory(
-                num_qubits,
+                total=num_qubits,
                 allocated=0,
                 sim_reg=QrackSimulator(qubitCount=num_qubits, **self.pyqrack_options),
             )

--- a/src/bloqade/pyqrack/target.py
+++ b/src/bloqade/pyqrack/target.py
@@ -50,7 +50,7 @@ class PyQrack:
             return PyQrackInterpreter(
                 mt.dialects,
                 memory=DynamicMemory(
-                    QrackSimulator(qubitCount=0, **self.pyqrack_options)
+                    sim_reg=QrackSimulator(qubitCount=0, **self.pyqrack_options)
                 ),
             )
         else:
@@ -64,11 +64,11 @@ class PyQrack:
                 )
 
             num_qubits = max(address_analysis.qubit_count, self.min_qubits)
-            self.pyqrack_options.pop("qubitCount", None)
+            options = {**self.pyqrack_options, "qubitCount": num_qubits}
             memory = StackMemory(
                 total=num_qubits,
                 allocated=0,
-                sim_reg=QrackSimulator(qubitCount=num_qubits, **self.pyqrack_options),
+                sim_reg=QrackSimulator(**options),
             )
 
             return PyQrackInterpreter(mt.dialects, memory=memory)


### PR DESCRIPTION
There were bugs in the implementation of the parallel dialects. Namely, they were not using the API for the `QrackSimulator` properly. Also I moved the sim_reg property to the ABC just to make hints work. 