### PR TITLE
Resetting memory creates new `QrackSimulator`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack<=1.35.7",
+    "pyqrack<=1.35.8",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu<=1.35.7",
+    "pyqrack-cpu<=1.35.8",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda<=1.35.7",
+    "pyqrack-cuda<=1.35.8",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack==1.35.7",
+    "pyqrack<=1.35.7",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu==1.35.7",
+    "pyqrack-cpu<=1.35.7",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda==1.35.7",
+    "pyqrack-cuda<=1.35.7",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack<=1.35.8",
+    "pyqrack<=1.35.9",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu<=1.35.8",
+    "pyqrack-cpu<=1.35.9",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda<=1.35.8",
+    "pyqrack-cuda<=1.35.9",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack~=1.35.10",
+    "pyqrack>=1.36.1",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu~=1.35.10",
+    "pyqrack-cpu>=1.36.1",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda~=1.35.10",
+    "pyqrack-cuda>=1.36.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack>=1.35.5",
+    "pyqrack~=1.35.5",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu>=1.35.5",
+    "pyqrack-cpu~=1.35.5",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda>=1.35.5",
+    "pyqrack-cuda~=1.35.5",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack<=1.35.10",
+    "pyqrack>=1.35.10",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu<=1.35.10",
+    "pyqrack-cpu>=1.35.10",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda<=1.35.10",
+    "pyqrack-cuda>=1.35.10",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack==1.35.6",
+    "pyqrack==1.35.7",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu==1.35.6",
+    "pyqrack-cpu==1.35.7",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda==1.35.6",
+    "pyqrack-cuda==1.35.7",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack==1.35.5",
+    "pyqrack==1.35.6",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu==1.35.5",
+    "pyqrack-cpu==1.35.6",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda==1.35.5",
+    "pyqrack-cuda==1.35.6",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack<=1.35.9",
+    "pyqrack<=1.35.10",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu<=1.35.9",
+    "pyqrack-cpu<=1.35.10",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda<=1.35.9",
+    "pyqrack-cuda<=1.35.10",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack~=1.35.5",
+    "pyqrack==1.35.5",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu~=1.35.5",
+    "pyqrack-cpu==1.35.5",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda~=1.35.5",
+    "pyqrack-cuda==1.35.5",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
 
 [project.optional-dependencies]
 pyqrack = [
-    "pyqrack>=1.35.10",
+    "pyqrack~=1.35.10",
 ]
 pyqrack-cpu = [
-    "pyqrack-cpu>=1.35.10",
+    "pyqrack-cpu~=1.35.10",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda>=1.35.10",
+    "pyqrack-cuda~=1.35.10",
 ]
 
 [build-system]

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -1,4 +1,3 @@
-import os
 import abc
 import typing
 from dataclasses import field, dataclass
@@ -22,23 +21,19 @@ class PyQrackOptions(typing.TypedDict):
     isPaged: bool
     isCpuGpuHybrid: bool
     isOpenCL: bool
-    isHostPointer: bool
 
 
 def _default_pyqrack_args() -> PyQrackOptions:
     return PyQrackOptions(
-        qubitCount=0,
+        qubitCount=-1,
         isTensorNetwork=False,
         isSchmidtDecomposeMulti=True,
         isSchmidtDecompose=True,
-        isStabilizerHybrid=False,
+        isStabilizerHybrid=True,
         isBinaryDecisionTree=True,
         isPaged=True,
         isCpuGpuHybrid=True,
         isOpenCL=True,
-        isHostPointer=(
-            True if os.environ.get("PYQRACK_HOST_POINTER_DEFAULT_ON") else False
-        ),
     )
 
 

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -1,6 +1,7 @@
 import abc
 import typing
 from dataclasses import field, dataclass
+from unittest.mock import Mock
 
 import numpy as np
 from pyqrack import QrackSimulator
@@ -40,7 +41,7 @@ def _default_pyqrack_args() -> PyQrackOptions:
 
 @dataclass
 class MemoryABC(abc.ABC):
-    pyqrack_options: PyQrackOptions
+    pyqrack_options: PyQrackOptions = field(default_factory=_default_pyqrack_args)
     sim_reg: "QrackSimulator" = field(init=False)
 
     @abc.abstractmethod
@@ -56,9 +57,26 @@ class MemoryABC(abc.ABC):
 
 
 @dataclass
+class MockMemory(MemoryABC):
+    """Mock memory for testing purposes."""
+
+    allocated: int = field(init=False, default=0)
+
+    def allocate(self, n_qubits: int):
+        allocated = self.allocated + n_qubits
+        result = tuple(range(self.allocated, allocated))
+        self.allocated = allocated
+        return result
+
+    def reset(self):
+        self.allocated = 0
+        self.sim_reg = Mock()
+
+
+@dataclass
 class StackMemory(MemoryABC):
-    total: int
-    allocated: int
+    total: int = field(kw_only=True)
+    allocated: int = field(init=False, default=0)
 
     def allocate(self, n_qubits: int):
         curr_allocated = self.allocated

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -1,3 +1,4 @@
+import os
 import abc
 import typing
 from dataclasses import field, dataclass
@@ -28,14 +29,16 @@ def _default_pyqrack_args() -> PyQrackOptions:
     return PyQrackOptions(
         qubitCount=0,
         isTensorNetwork=False,
-        isSchmidtDecomposeMulti=False,
-        isSchmidtDecompose=False,
+        isSchmidtDecomposeMulti=True,
+        isSchmidtDecompose=True,
         isStabilizerHybrid=False,
         isBinaryDecisionTree=True,
-        isPaged=False,
-        isCpuGpuHybrid=False,
-        isOpenCL=False,
-        isHostPointer=False,
+        isPaged=True,
+        isCpuGpuHybrid=True,
+        isOpenCL=True,
+        isHostPointer=(
+            True if os.environ.get("PYQRACK_HOST_POINTER_DEFAULT_ON") else False
+        ),
     )
 
 

--- a/src/bloqade/pyqrack/target.py
+++ b/src/bloqade/pyqrack/target.py
@@ -51,7 +51,6 @@ class PyQrack:
             memory = StackMemory(
                 options,
                 total=num_qubits,
-                allocated=0,
             )
 
             return PyQrackInterpreter(mt.dialects, memory=memory)

--- a/src/bloqade/pyqrack/target.py
+++ b/src/bloqade/pyqrack/target.py
@@ -30,8 +30,14 @@ class PyQrack:
     pyqrack_options: PyQrackOptions = field(default_factory=_default_pyqrack_args)
     """Options to pass to the QrackSimulator object, node `qubitCount` will be overwritten."""
 
+    def __post_init__(self):
+        self.pyqrack_options = PyQrackOptions(
+            {**_default_pyqrack_args(), **self.pyqrack_options}
+        )
+
     def _get_interp(self, mt: ir.Method[Params, RetType]):
         if self.dynamic_qubits:
+
             options = self.pyqrack_options.copy()
             options["qubitCount"] = 0
             return PyQrackInterpreter(mt.dialects, memory=DynamicMemory(options))

--- a/src/bloqade/pyqrack/target.py
+++ b/src/bloqade/pyqrack/target.py
@@ -39,7 +39,7 @@ class PyQrack:
         if self.dynamic_qubits:
 
             options = self.pyqrack_options.copy()
-            options["qubitCount"] = 0
+            options["qubitCount"] = -1
             return PyQrackInterpreter(mt.dialects, memory=DynamicMemory(options))
         else:
             address_analysis = AddressAnalysis(mt.dialects)

--- a/test/runtime/noise/native/test_loss.py
+++ b/test/runtime/noise/native/test_loss.py
@@ -10,7 +10,6 @@ simulation = qasm2.extended.add(native)
 
 
 def run_mock(program: ir.Method, rng_state: Mock | None = None):
-    rng_state = rng_state or Mock()
     PyQrackInterpreter(
         program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
     ).run(program, ()).expect()

--- a/test/runtime/noise/native/test_loss.py
+++ b/test/runtime/noise/native/test_loss.py
@@ -1,10 +1,21 @@
 from unittest.mock import Mock
 
+from kirin import ir
 from bloqade import qasm2
 from bloqade.noise import native
-from bloqade.pyqrack import StackMemory, PyQrackInterpreter, reg
+from bloqade.pyqrack import PyQrackInterpreter, reg
+from bloqade.pyqrack.base import MockMemory
 
 simulation = qasm2.extended.add(native)
+
+
+def run_mock(program: ir.Method, rng_state: Mock | None = None):
+    rng_state = rng_state or Mock()
+    PyQrackInterpreter(
+        program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
+    ).run(program, ()).expect()
+    assert isinstance(mock := memory.sim_reg, Mock)
+    return mock
 
 
 def test_atom_loss():
@@ -21,9 +32,9 @@ def test_atom_loss():
     rng_state = Mock()
     rng_state.uniform.return_value = 0.7
     input = reg.CRegister(1)
-    memory = StackMemory(total=2, allocated=0, sim_reg=Mock())
+    memory = MockMemory()
 
-    result: reg.PyQrackReg[Mock] = (
+    result: reg.PyQrackReg = (
         PyQrackInterpreter(simulation, memory=memory, rng_state=rng_state)
         .run(test_atom_loss, (input,))
         .expect()

--- a/test/runtime/noise/native/test_pauli.py
+++ b/test/runtime/noise/native/test_pauli.py
@@ -3,19 +3,18 @@ from unittest.mock import Mock, call
 from kirin import ir
 from bloqade import qasm2
 from bloqade.noise import native
-from bloqade.pyqrack import StackMemory, PyQrackInterpreter
+from bloqade.pyqrack.base import MockMemory, PyQrackInterpreter
 
 simulation = qasm2.extended.add(native)
 
 
-def run_mock(size, program: ir.Method, rng_state: Mock) -> Mock:
-    memory = StackMemory(total=2, allocated=0, sim_reg=Mock())
-
-    PyQrackInterpreter(program.dialects, memory=memory, rng_state=rng_state).run(
-        program, ()
-    ).expect()
-
-    return memory.sim_reg
+def run_mock(program: ir.Method, rng_state: Mock | None = None):
+    rng_state = rng_state or Mock()
+    PyQrackInterpreter(
+        program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
+    ).run(program, ()).expect()
+    assert isinstance(mock := memory.sim_reg, Mock)
+    return mock
 
 
 def test_pauli_channel():
@@ -38,7 +37,7 @@ def test_pauli_channel():
 
     rng_state = Mock()
     rng_state.choice.side_effect = ["y", "i"]
-    sim_reg = run_mock(2, test_atom_loss, rng_state)
+    sim_reg = run_mock(test_atom_loss, rng_state)
     sim_reg.assert_has_calls([call.y(0)])
 
 
@@ -82,7 +81,7 @@ def test_cz_pauli_channel_false():
     rng_state = Mock()
     rng_state.choice.side_effect = ["y"]
     rng_state.uniform.return_value = 0.5
-    sim_reg = run_mock(2, test_atom_loss, rng_state)
+    sim_reg = run_mock(test_atom_loss, rng_state)
     sim_reg.assert_has_calls([call.mcz([0], 1), call.force_m(0, 0), call.y(1)])
 
 
@@ -123,7 +122,7 @@ def test_cz_pauli_channel_true():
     rng_state = Mock()
     rng_state.choice.side_effect = ["y", "x"]
     rng_state.uniform.return_value = 0.5
-    sim_reg = run_mock(2, test_atom_loss, rng_state)
+    sim_reg = run_mock(test_atom_loss, rng_state)
 
     sim_reg.assert_has_calls([call.y(0), call.x(1), call.mcz([0], 1)])
 

--- a/test/runtime/noise/native/test_pauli.py
+++ b/test/runtime/noise/native/test_pauli.py
@@ -9,7 +9,6 @@ simulation = qasm2.extended.add(native)
 
 
 def run_mock(program: ir.Method, rng_state: Mock | None = None):
-    rng_state = rng_state or Mock()
     PyQrackInterpreter(
         program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
     ).run(program, ()).expect()

--- a/test/runtime/test_qrack.py
+++ b/test/runtime/test_qrack.py
@@ -3,15 +3,17 @@ from unittest.mock import Mock, call
 
 from kirin import ir
 from pytest import mark
-from bloqade import qasm2, pyqrack
+from bloqade import qasm2
+from bloqade.pyqrack.base import MockMemory, PyQrackInterpreter
 
 
-def run_mock(size: int, program: ir.Method) -> Mock:
-    memory = pyqrack.StackMemory(size, 0, sim_reg=Mock())
-    interp = pyqrack.PyQrackInterpreter(program.dialects, memory=memory)
-    interp.run(program, ())
-
-    return memory.sim_reg
+def run_mock(program: ir.Method, rng_state: Mock | None = None):
+    rng_state = rng_state or Mock()
+    PyQrackInterpreter(
+        program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
+    ).run(program, ()).expect()
+    assert isinstance(mock := memory.sim_reg, Mock)
+    return mock
 
 
 def test_basic_gates():
@@ -32,7 +34,7 @@ def test_basic_gates():
         qasm2.sx(q[2])
         qasm2.sxdg(q[0])
 
-    sim_reg = run_mock(3, program)
+    sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
             call.h(0),
@@ -58,7 +60,7 @@ def test_rotation_gates():
         qasm2.ry(q[1], 0.5)
         qasm2.rz(q[2], 0.5)
 
-    sim_reg = run_mock(3, program)
+    sim_reg = run_mock(program)
 
     sim_reg.assert_has_calls(
         [
@@ -78,7 +80,7 @@ def test_u_gates():
         qasm2.u2(q[1], 0.2, 0.1)
         qasm2.u1(q[2], 0.2)
 
-    sim_reg = run_mock(3, program)
+    sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
             call.u(0, 0.5, 0.2, 0.1),
@@ -102,7 +104,7 @@ def test_basic_control_gates():
         qasm2.csx(q[1], q[2])
         qasm2.swap(q[0], q[2])  # requires new bloqade version
 
-    sim_reg = run_mock(3, program)
+    sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
             call.mcx([0], 1),
@@ -127,7 +129,7 @@ def test_special_control():
         qasm2.cu(q[0], q[1], 0.5, 0.2, 0.1, 0.8)
         qasm2.cswap(q[0], q[1], q[2])
 
-    sim_reg = run_mock(3, program)
+    sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
             call.mcr(1, 0.5, [0], 1),
@@ -150,7 +152,7 @@ def test_extended():
         qasm2.parallel.u([q[0], q[1]], theta=0.5, phi=0.2, lam=0.1)
         qasm2.parallel.rz([q[0], q[1]], 0.5)
 
-    sim_reg = run_mock(4, program)
+    sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
             call.mcz([0], 1),

--- a/test/runtime/test_qrack.py
+++ b/test/runtime/test_qrack.py
@@ -2,7 +2,6 @@ import math
 from unittest.mock import Mock, call
 
 from kirin import ir
-from pytest import mark
 from bloqade import qasm2
 from bloqade.pyqrack.base import MockMemory, PyQrackInterpreter
 
@@ -90,7 +89,6 @@ def test_u_gates():
     )
 
 
-@mark.xfail(reason="binding for swap not implemented")
 def test_basic_control_gates():
 
     @qasm2.main

--- a/test/runtime/test_qrack.py
+++ b/test/runtime/test_qrack.py
@@ -7,7 +7,6 @@ from bloqade.pyqrack.base import MockMemory, PyQrackInterpreter
 
 
 def run_mock(program: ir.Method, rng_state: Mock | None = None):
-    rng_state = rng_state or Mock()
     PyQrackInterpreter(
         program.dialects, memory=(memory := MockMemory()), rng_state=rng_state
     ).run(program, ()).expect()


### PR DESCRIPTION
For `multi_run` the interpreter is not regenerated. As a result if the result returns a qubit or a register object all the results will share the same `QrackSimulator` object which will lead to unexpected behavior when one result alters the state of the simulator, say for example, measure the qubits, that will force all the other results to have the same behavior due to how PyQrack interprets measurement. This also applies when the interpreter calls `reset_all` it will reset the qubit for all of the previous results. 

So to avoid this behavior every time I reset the memory I create a new QrackSimulator instance. 

Warning this PR is breaking in terms of the arguments allowed by the simulator. 
